### PR TITLE
Add Sendable conformance to ReadWriteLock

### DIFF
--- a/Sources/ReadWriteLock/ReadWriteLock.swift
+++ b/Sources/ReadWriteLock/ReadWriteLock.swift
@@ -9,7 +9,7 @@ import Darwin
 
 // MARK: - ReadWriteLock Definition
 
-public class ReadWriteLock {
+public final class ReadWriteLock: @unchecked Sendable {
 
     // MARK: Private Properties
 


### PR DESCRIPTION
This works with the latest version of Swift 5, and is required to use it across threads in Swift 6.